### PR TITLE
Add max version for jax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "gymnasium>=1.0.0",
-    "jax>=0.5",
+    "jax>=0.5,<0.7",
     "jaxlib",
     "optax",
     "distrax",


### PR DESCRIPTION
- Fixes jax version to be <0.7, currently required due to distrax functions that were remove in jax 0.7.0