### PR TITLE
[MRG] Fix memory leaks

### DIFF
--- a/rl_blox/algorithm/sac.py
+++ b/rl_blox/algorithm/sac.py
@@ -471,9 +471,7 @@ def train_sac(
         replay_buffer = ReplayBuffer(buffer_size)
 
     train_step = partial(train_step_with_loss, sac_loss)
-    train_step = partial(nnx.jit, static_argnames=("gamma", "alpha"))(
-        train_step
-    )
+    train_step = partial(nnx.jit, static_argnames=("gamma",))(train_step)
 
     if logger is not None:
         logger.start_new_episode()

--- a/rl_blox/algorithm/td7.py
+++ b/rl_blox/algorithm/td7.py
@@ -74,8 +74,6 @@ def _sum_of_qnet_losses(
     static_argnames=[
         "gamma",
         "min_priority",
-        "q_min",
-        "q_max",
     ],
 )
 def td7_update_critic(


### PR DESCRIPTION
`static_argnames` in jit-compiled functions must be constant. JAX will compile a new function for each different value. This is not just slow, but also accumulates a lot of memory that is not released properly for some reason.