### PR TITLE
MRG: BUG: Fix normalization in state encoder

### DIFF
--- a/rl_blox/blox/embedding/sale.py
+++ b/rl_blox/blox/embedding/sale.py
@@ -69,7 +69,7 @@ class SALE(nnx.Module):
     def __init__(
         self, state_embedding: nnx.Module, state_action_embedding: nnx.Module
     ):
-        self.state_embedding = state_embedding
+        self._state_embedding = state_embedding
         self.state_action_embedding = state_action_embedding
 
     def __call__(


### PR DESCRIPTION
In the previous version, the constructor was overwriting the `state_embedding` function with an nnx.Module, hence, removing the normalization.