### PR TITLE
SubtrajectoryReplayBuffer[+PER]: Add option mrq_mode=off (no trans-episode subtrajectories, no sample delay)

### DIFF
--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -134,6 +134,13 @@ class ReplayBuffer:
         self.Batch = namedtuple("Batch", self.buffer)
 
 
+def dilate_right(a, n):
+    for _ in range(n):
+        a_shifted_right = np.concatenate([a[-1:], a[:-1]])
+        a = np.bitwise_or(a, a_shifted_right)
+    return a
+
+
 class SubtrajectoryReplayBuffer:
     """Replay buffer for sampling batches of subtrajectories.
 
@@ -375,7 +382,7 @@ class SubtrajectoryReplayBuffer:
         assert batch_size > 0
         assert horizon > 0
 
-        indices = self._sample_idx(batch_size, rng)
+        indices = self._sample_idx(batch_size, horizon, rng)
         # TODO % self.current_len or % self.buffer_size?
         # - maybe self.buffer_size is possible because of the mask?
         indices = (
@@ -405,10 +412,20 @@ class SubtrajectoryReplayBuffer:
 
         return batch
 
+    def _mask_for_horizon(self, horizon: int):
+        if self._legacy_mode:
+            return self.mask_
+        assert horizon >= 1 and horizon <= self.horizon
+        if horizon == self.horizon:
+            return self.mask_
+        difference = self.horizon - horizon
+        return dilate_right(self.mask_, difference)
+
     def _sample_idx(
-        self, batch_size: int, rng: np.random.Generator
+        self, batch_size: int, horizon: int, rng: np.random.Generator
     ) -> npt.NDArray[int]:
-        nz = np.nonzero(self.mask_)[0]
+        mask = self._mask_for_horizon(horizon)
+        nz = np.nonzero(mask)[0]
         indices = rng.integers(0, len(nz), size=batch_size)
         return nz[indices]
 
@@ -778,10 +795,11 @@ class SubtrajectoryReplayBufferPER(SubtrajectoryReplayBuffer):
         self.priority.initialize_priority(inserted_at)
 
     def _sample_idx(
-        self, batch_size: int, rng: np.random.Generator
+        self, batch_size: int, horizon: int, rng: np.random.Generator
     ) -> npt.NDArray[int]:
+        mask = self._mask_for_horizon(horizon)
         return self.priority.prioritized_sampling(
-            self.current_len, batch_size, rng, self.mask_
+            self.current_len, batch_size, rng, mask
         )
 
     def update_priority(self, priority):

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -135,6 +135,17 @@ class ReplayBuffer:
 
 
 def dilate_right(a, n):
+    """Given a mask 'a' of 0s and 1s, return a mask that is created from 'a'
+    by setting all n values to the right of every 1 in 'a' to 1 too. Wrap
+    around at the end.
+
+    Examples
+    --------
+    a=[0, 1, 0, 0, 1, 0]
+    - n=0 -> [0, 1, 0, 0, 1, 0]
+    - n=1 -> [0, 1, 1, 0, 1, 1]
+    - n=2 -> [1, 1, 1, 1, 1, 1]
+    """
     for _ in range(n):
         a_shifted_right = np.concatenate([a[-1:], a[:-1]])
         a = np.bitwise_or(a, a_shifted_right)
@@ -150,7 +161,8 @@ class SubtrajectoryReplayBuffer:
         Maximum size of the buffer.
 
     horizon : int, optional
-        Maximum length of the horizon.
+        Maximum length of the horizon. During sampling, a shorter horizon may
+        be specified.
 
     keys : list[str], optional
         Names of the quantities that should be stored in the replay buffer.
@@ -181,6 +193,18 @@ class SubtrajectoryReplayBuffer:
           specified on construction, the mask of allowed start indices for
           sample subtrajectories will be extended to the right by the
           difference.
+        
+        For MRQ, subtrajectories that start in one episode and end in the next
+        are expected and required for best performance, for two reasons:
+        1. MRQ benefits from having all transitions up to the last transition of
+        an episode as the first transition in a subtrajectory. For the last
+        horizon-1 transitions this is achieved by sampling subtrajectories that
+        end in next episode.
+        2. These trans-episode trajectories do not corrupt the learning process
+        because MRQ discounts rewards of transitions following a termination
+        transition, effectively ignoring the second episode in two-episode
+        subtrajectories.
+
         Note that if mrq_mode is True, add_sample() returns a list[int].
         If mrq_mode is False, add_sample() returns just an int.
     """
@@ -236,6 +260,9 @@ class SubtrajectoryReplayBuffer:
         # track if there are any terminal transitions in the buffer
         self.environment_terminates = False
         self.horizon = horizon
+        # mask that is 1 at an index if that index in the buffer can be the
+        # first index of a subtrajectory to be sampled with sample_batch
+        # if that is called with horizon==self.horizon, or 0 otherwise.
         self.mask_ = np.zeros(self.buffer_size, dtype=int)
         self._mrq_mode = mrq_mode
 
@@ -336,6 +363,10 @@ class SubtrajectoryReplayBuffer:
             ]
 
             self.mask_[self.insert_idx % self.buffer_size] = 0
+
+            # mask out truncated subtrajectories or mask in the last indices
+            # before termination to ensure that these transitions may appear
+            # as the first transitions in sampled subtrajectories
             past_idx = (
                 self.insert_idx
                 - np.arange(min(self.episode_timesteps, self.horizon))
@@ -343,7 +374,7 @@ class SubtrajectoryReplayBuffer:
             ) % self.buffer_size
             self.mask_[past_idx] = (
                 0 if sample["truncated"] else 1
-            )  # mask out truncated subtrajectories
+            )
 
             inserted_at += [self.insert_idx]
             self.insert_idx = (self.insert_idx + 1) % self.buffer_size
@@ -416,6 +447,26 @@ class SubtrajectoryReplayBuffer:
         return batch
 
     def _mask_for_horizon(self, horizon: int):
+        """Get the mask for starting indices to be sampled under the given
+        sampling horizon.
+
+        If mrq_mode is True, this is just self.mask_.
+
+        If mrq_mode is False, and the given sampling horizon is the same as
+        self.horizon, this is also just self.mask_. If however mrq_mode is
+        False and the sampling horizon is shorter, recalculate the mask
+        so as to allow for sampling from later starting indices enabled by
+        the shorter horizon. This recalculation is performed by dilate_right().
+
+        If, for example, self.horizon is 5, self.mask_[0] is 1 and
+        self.mask_[1:] is 0, this means transitions [0,5) may be sampled.
+        For a sampling horizon of 5, this means only one subtrajectory may
+        be sampled, namely the one starting at index 0. It has length 5 and
+        contains all transitions at indices in [0,5). For a sampling horizon
+        of 3, however, this means subtrajectories may be sampled starting at
+        either 0, 1, or 2, as all these subtrajectories (of length 3) only
+        contain transitions in [0,5).
+        """
         if self._mrq_mode:
             return self.mask_
         assert horizon >= 1 and horizon <= self.horizon

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -258,9 +258,9 @@ class SubtrajectoryReplayBuffer:
                 - np.arange(min(self.episode_timesteps, self.horizon))
                 - 1
             ) % self.buffer_size
-            self.mask_[past_idx] = (
-                0 if sample["truncated"] else 1
-            )  # mask out truncated subtrajectories
+            # mask out truncated subtrajectories
+            if sample["truncated"]:
+                self.mask_[past_idx] = 0
 
             inserted_at += [self.insert_idx]
             self.insert_idx = (self.insert_idx + 1) % self.buffer_size

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -159,6 +159,20 @@ class SubtrajectoryReplayBuffer:
 
     discrete_actions : bool, optional
         Changes the default dtype for actions to int.
+
+    legacy_mode : bool, optional
+        If True, termination and truncation are handled the way the original
+        MRQ implementation of this replay buffer did, which may be considered
+        incorrect. If False, our fixes are included. These fixes are:
+        - No subtrajectories will be generated that include transitions from
+          more than one episode. Previously, this was possible for
+          subtrajectories that would start close to the end of a terminated
+          episode.
+        - There is no delay in added transitions for being eligible to be
+          sampled any more. Originally, the most recently added transition
+          would in general not be part of the sample_batch() return value.
+        Note that if legacy_mode is True, add_sample() returns a list[int].
+        If legacy_mode is False, add_sample() returns just an int.
     """
 
     def __init__(
@@ -168,6 +182,7 @@ class SubtrajectoryReplayBuffer:
         keys: list[str] | None = None,
         dtypes: list[npt.DTypeLike] | None = None,
         discrete_actions: bool = False,
+        legacy_mode: bool = False,
     ):
         assert buffer_size > 0
         assert horizon > 0
@@ -212,13 +227,35 @@ class SubtrajectoryReplayBuffer:
         self.environment_terminates = False
         self.horizon = horizon
         self.mask_ = np.zeros(self.buffer_size, dtype=int)
+        self._legacy_mode = legacy_mode
 
-    def add_sample(self, **sample) -> int:
+    def add_sample(self, **sample) -> int | list[int]:
         """Add transition sample to the replay buffer.
 
         Note that the individual arguments have to be passed as keyword
         arguments with keys matching the ones passed to the constructor or
         the default keys respectively.
+
+        Returns
+        -------
+        int | list[int]
+            Index in the buffer at which the sample was inserted.
+            Note that if legacy_mode was set to True on construction,
+            this is a list of indices (multiple samples may be inserted).
+        """
+        if self._legacy_mode:
+            return self._add_sample_legacy(**sample)
+        else:
+            return self._add_sample(**sample)
+
+
+    def _add_sample(self, **sample) -> int:
+        """Add transition sample to the replay buffer.
+
+        Notes
+        -----
+        This is the updated version of _add_sample(). See documentation
+        for __init__(): legacy_mode.
         """
         if self.current_len == 0:
             for k, v in sample.items():
@@ -244,6 +281,64 @@ class SubtrajectoryReplayBuffer:
         self.insert_idx = (self.insert_idx + 1) % self.buffer_size
 
         if sample["terminated"] or sample["truncated"]:
+            self.episode_timesteps = 0
+
+        return inserted_at
+
+    def _add_sample_legacy(self, **sample) -> list[int]:
+        """Add transition sample to the replay buffer.
+
+        Notes
+        -----
+        This is the legacy version of _add_sample(). See documentation
+        for __init__() -> legacy_mode.
+        """
+        if self.current_len == 0:
+            for k, v in sample.items():
+                assert k in self.buffer, f"{k} not in {self.buffer.keys()}"
+                self.buffer[k] = np.empty(
+                    (self.buffer_size,) + np.asarray(v).shape,
+                    dtype=self.buffer[k].dtype,
+                )
+        for k, v in sample.items():
+            self.buffer[k][self.insert_idx] = v
+
+        self.current_len = min(self.current_len + 1, self.buffer_size)
+        self.episode_timesteps += 1
+        if sample["terminated"]:
+            self.environment_terminates = True
+
+        self.mask_[self.insert_idx] = 0
+        if self.episode_timesteps > self.horizon:
+            self.mask_[(self.insert_idx - self.horizon) % self.buffer_size] = 1
+
+        inserted_at = [self.insert_idx]
+        self.insert_idx = (self.insert_idx + 1) % self.buffer_size
+
+        if sample["terminated"] or sample["truncated"]:
+            for k in self.buffer:
+                if k == "reward":
+                    self.buffer[k][self.insert_idx] = 0.0
+                else:
+                    self.buffer[k][self.insert_idx] = sample[k]
+            self.buffer["observation"][self.insert_idx] = sample[
+                "next_observation"
+            ]
+
+            self.mask_[self.insert_idx % self.buffer_size] = 0
+            past_idx = (
+                self.insert_idx
+                - np.arange(min(self.episode_timesteps, self.horizon))
+                - 1
+            ) % self.buffer_size
+            self.mask_[past_idx] = (
+                0 if sample["truncated"] else 1
+            )  # mask out truncated subtrajectories
+
+            inserted_at += [self.insert_idx]
+            self.insert_idx = (self.insert_idx + 1) % self.buffer_size
+            self.current_len = min(self.current_len + 1, self.buffer_size)
+
             self.episode_timesteps = 0
 
         return inserted_at
@@ -651,6 +746,9 @@ class SubtrajectoryReplayBufferPER(SubtrajectoryReplayBuffer):
 
     discrete_actions : bool, optional
         Changes the default dtype for actions to int.
+
+    legacy_mode : bool, optional
+        See documentation for SubtrajectoryReplayBuffer.__init__(): legacy_mode.
     """
 
     priority: PriorityBuffer
@@ -662,8 +760,11 @@ class SubtrajectoryReplayBufferPER(SubtrajectoryReplayBuffer):
         keys: list[str] | None = None,
         dtypes: list[npt.DTypeLike] | None = None,
         discrete_actions: bool = False,
+        legacy_mode: bool = False,
     ):
-        super().__init__(buffer_size, horizon, keys, dtypes, discrete_actions)
+        super().__init__(
+            buffer_size, horizon, keys, dtypes, discrete_actions, legacy_mode
+        )
         self.priority = PriorityBuffer(buffer_size)
 
     def add_sample(self, **sample):

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -258,7 +258,7 @@ class SubtrajectoryReplayBuffer:
                 - np.arange(min(self.episode_timesteps, self.horizon))
                 - 1
             ) % self.buffer_size
-            # mask out truncated subtrajectories
+
             if sample["truncated"]:
                 self.mask_[past_idx] = 0
 

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -213,7 +213,7 @@ class SubtrajectoryReplayBuffer:
         self.horizon = horizon
         self.mask_ = np.zeros(self.buffer_size, dtype=int)
 
-    def add_sample(self, **sample) -> list[int]:
+    def add_sample(self, **sample) -> int:
         """Add transition sample to the replay buffer.
 
         Note that the individual arguments have to be passed as keyword
@@ -236,36 +236,14 @@ class SubtrajectoryReplayBuffer:
             self.environment_terminates = True
 
         self.mask_[self.insert_idx] = 0
-        if self.episode_timesteps >= self.horizon:
+        if self.episode_timesteps >= self.horizon and not sample["truncated"]:
+            # mask in the index that the new subtrajectory starts with
             self.mask_[(self.insert_idx - self.horizon + 1) % self.buffer_size] = 1
 
-        inserted_at = [self.insert_idx]
+        inserted_at = self.insert_idx
         self.insert_idx = (self.insert_idx + 1) % self.buffer_size
 
         if sample["terminated"] or sample["truncated"]:
-            for k in self.buffer:
-                if k == "reward":
-                    self.buffer[k][self.insert_idx] = 0.0
-                else:
-                    self.buffer[k][self.insert_idx] = sample[k]
-            self.buffer["observation"][self.insert_idx] = sample[
-                "next_observation"
-            ]
-
-            self.mask_[self.insert_idx] = 0
-            past_idx = (
-                self.insert_idx
-                - np.arange(min(self.episode_timesteps, self.horizon))
-                - 1
-            ) % self.buffer_size
-
-            if sample["truncated"]:
-                self.mask_[past_idx] = 0
-
-            inserted_at += [self.insert_idx]
-            self.insert_idx = (self.insert_idx + 1) % self.buffer_size
-            self.current_len = min(self.current_len + 1, self.buffer_size)
-
             self.episode_timesteps = 0
 
         return inserted_at
@@ -370,7 +348,7 @@ class PriorityBuffer:
         self.priority = np.empty(buffer_size, dtype=float)
         self.sampled_indices = np.empty(0, dtype=int)
 
-    def initialize_priority(self, insert_idx: npt.NDArray[int]):
+    def initialize_priority(self, insert_idx: int):
         """Initialize the priority of the next inserted sample."""
         self.priority[insert_idx] = self.max_priority
 

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -236,8 +236,8 @@ class SubtrajectoryReplayBuffer:
             self.environment_terminates = True
 
         self.mask_[self.insert_idx] = 0
-        if self.episode_timesteps > self.horizon:
-            self.mask_[(self.insert_idx - self.horizon) % self.buffer_size] = 1
+        if self.episode_timesteps >= self.horizon:
+            self.mask_[(self.insert_idx - self.horizon + 1) % self.buffer_size] = 1
 
         inserted_at = [self.insert_idx]
         self.insert_idx = (self.insert_idx + 1) % self.buffer_size

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -167,19 +167,22 @@ class SubtrajectoryReplayBuffer:
     discrete_actions : bool, optional
         Changes the default dtype for actions to int.
 
-    legacy_mode : bool, optional
+    mrq_mode : bool, optional
         If True, termination and truncation are handled the way the original
-        MRQ implementation of this replay buffer did, which may be considered
-        incorrect. If False, our fixes are included. These fixes are:
+        MRQ implementation of this replay buffer did, which may or may not be
+        considered incorrect. If False, the following changes are included:
         - No subtrajectories will be generated that include transitions from
-          more than one episode. Previously, this was possible for
-          subtrajectories that would start close to the end of a terminated
-          episode.
+          more than one episode. With mrq_mode, this is possible for
+          subtrajectories that start close to the end of a terminated episode.
         - There is no delay in added transitions for being eligible to be
           sampled any more. Originally, the most recently added transition
           would in general not be part of the sample_batch() return value.
-        Note that if legacy_mode is True, add_sample() returns a list[int].
-        If legacy_mode is False, add_sample() returns just an int.
+        - If sample_batch() is called with a horizon shorter than the horizon
+          specified on construction, the mask of allowed start indices for
+          sample subtrajectories will be extended to the right by the
+          difference.
+        Note that if mrq_mode is True, add_sample() returns a list[int].
+        If mrq_mode is False, add_sample() returns just an int.
     """
 
     def __init__(
@@ -189,7 +192,7 @@ class SubtrajectoryReplayBuffer:
         keys: list[str] | None = None,
         dtypes: list[npt.DTypeLike] | None = None,
         discrete_actions: bool = False,
-        legacy_mode: bool = False,
+        mrq_mode: bool = True,
     ):
         assert buffer_size > 0
         assert horizon > 0
@@ -234,7 +237,7 @@ class SubtrajectoryReplayBuffer:
         self.environment_terminates = False
         self.horizon = horizon
         self.mask_ = np.zeros(self.buffer_size, dtype=int)
-        self._legacy_mode = legacy_mode
+        self._mrq_mode = mrq_mode
 
     def add_sample(self, **sample) -> int | list[int]:
         """Add transition sample to the replay buffer.
@@ -247,11 +250,11 @@ class SubtrajectoryReplayBuffer:
         -------
         int | list[int]
             Index in the buffer at which the sample was inserted.
-            Note that if legacy_mode was set to True on construction,
+            Note that if mrq_mode was set to True on construction,
             this is a list of indices (multiple samples may be inserted).
         """
-        if self._legacy_mode:
-            return self._add_sample_legacy(**sample)
+        if self._mrq_mode:
+            return self._add_sample_mrq(**sample)
         else:
             return self._add_sample(**sample)
 
@@ -262,7 +265,7 @@ class SubtrajectoryReplayBuffer:
         Notes
         -----
         This is the updated version of _add_sample(). See documentation
-        for __init__(): legacy_mode.
+        for __init__(): mrq_mode.
         """
         if self.current_len == 0:
             for k, v in sample.items():
@@ -292,13 +295,13 @@ class SubtrajectoryReplayBuffer:
 
         return inserted_at
 
-    def _add_sample_legacy(self, **sample) -> list[int]:
+    def _add_sample_mrq(self, **sample) -> list[int]:
         """Add transition sample to the replay buffer.
 
         Notes
         -----
-        This is the legacy version of _add_sample(). See documentation
-        for __init__() -> legacy_mode.
+        This is the mrq version of _add_sample(). See documentation
+        for __init__(): mrq_mode.
         """
         if self.current_len == 0:
             for k, v in sample.items():
@@ -413,7 +416,7 @@ class SubtrajectoryReplayBuffer:
         return batch
 
     def _mask_for_horizon(self, horizon: int):
-        if self._legacy_mode:
+        if self._mrq_mode:
             return self.mask_
         assert horizon >= 1 and horizon <= self.horizon
         if horizon == self.horizon:
@@ -764,8 +767,8 @@ class SubtrajectoryReplayBufferPER(SubtrajectoryReplayBuffer):
     discrete_actions : bool, optional
         Changes the default dtype for actions to int.
 
-    legacy_mode : bool, optional
-        See documentation for SubtrajectoryReplayBuffer.__init__(): legacy_mode.
+    mrq_mode : bool, optional
+        See documentation for SubtrajectoryReplayBuffer.__init__(): mrq_mode.
     """
 
     priority: PriorityBuffer
@@ -777,10 +780,10 @@ class SubtrajectoryReplayBufferPER(SubtrajectoryReplayBuffer):
         keys: list[str] | None = None,
         dtypes: list[npt.DTypeLike] | None = None,
         discrete_actions: bool = False,
-        legacy_mode: bool = False,
+        mrq_mode: bool = True,
     ):
         super().__init__(
-            buffer_size, horizon, keys, dtypes, discrete_actions, legacy_mode
+            buffer_size, horizon, keys, dtypes, discrete_actions, mrq_mode
         )
         self.priority = PriorityBuffer(buffer_size)
 

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -207,6 +207,13 @@ class SubtrajectoryReplayBuffer:
 
         Note that if mrq_mode is True, add_sample() returns a list[int].
         If mrq_mode is False, add_sample() returns just an int.
+
+    Notes
+    -----
+    This is implemented as a ring buffer of size buffer_size to which
+    transition samples (or just samples) will be added at self._insert_idx.
+    This self._insert_idx is incremented after each sample addition and wraps
+    around at the end, overwriting previously added samples.
     """
 
     def __init__(

--- a/rl_blox/blox/replay_buffer.py
+++ b/rl_blox/blox/replay_buffer.py
@@ -252,7 +252,7 @@ class SubtrajectoryReplayBuffer:
                 "next_observation"
             ]
 
-            self.mask_[self.insert_idx % self.buffer_size] = 0
+            self.mask_[self.insert_idx] = 0
             past_idx = (
                 self.insert_idx
                 - np.arange(min(self.episode_timesteps, self.horizon))

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -80,8 +80,7 @@ def test_subtrajectory_replay_buffer():
 
     assert not buffer.environment_terminates
 
-    # Terminated / truncated states are counted as samples
-    assert len(buffer) == n_steps + n_episodes
+    assert len(buffer) == n_steps
 
     rng = np.random.default_rng(42)
     batch = buffer.sample_batch(32, 5, True, rng)
@@ -90,6 +89,7 @@ def test_subtrajectory_replay_buffer():
     assert batch.observation.shape[2] == 3
 
     assert np.count_nonzero(buffer.mask_) == n_steps - n_episodes * 5
+
 
 def add(buffer, obs, next_obs, term, trunc):
     buffer.add_sample(
@@ -101,6 +101,7 @@ def add(buffer, obs, next_obs, term, trunc):
         truncated=trunc,
     )
 
+
 @pytest.fixture
 def strb_for_masking():
     buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
@@ -108,23 +109,27 @@ def strb_for_masking():
         add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
     return buf
 
+
 def test_subtrajectory_replay_buffer_no_end(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=False, trunc=False)
     assert (buf.current_len == 5)
     assert (buf.mask_ == jnp.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])).all()
 
+
 def test_subtrajectory_replay_buffer_termination(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=True, trunc=False)
-    assert (buf.current_len == 6)
+    assert (buf.current_len == 5)
     assert (buf.mask_ == jnp.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])).all()
+
 
 def test_subtrajectory_replay_buffer_truncation(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=False, trunc=True)
-    assert (buf.current_len == 6)
+    assert (buf.current_len == 5)
     assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
 
 def test_subtrajectory_replay_buffer_has_horizon_as_min_episode_len():
     buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
@@ -132,13 +137,14 @@ def test_subtrajectory_replay_buffer_has_horizon_as_min_episode_len():
         add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
     assert buf.mask_.any()
     # ensure subtrajectories can be generated from a minimum-length episode
-    # otherwise an error will be thrown
+    # otherwise an error will be thrown from inside sample_batch
     _ = buf.sample_batch(
         batch_size=1,
         horizon=3,
         include_intermediate=True,
         rng=np.random.default_rng(0),
     )
+
 
 def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
     buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
@@ -158,8 +164,10 @@ def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(
     for obs_subseq in obs_subseqs:
         assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
 
-def test_subtrajectory_replay_buffer_may_produce_termination_transitions(strb_for_masking):
+
+def test_subtrajectory_replay_buffer_termination_transitions_are_always_last_without_next_ep(strb_for_masking):
     buf = strb_for_masking
+    # add termination transition as the last transition
     add(buf, obs=4, next_obs=5, term=True, trunc=False)
 
     _, _, _, _, terminated, _ = buf.sample_batch(
@@ -168,11 +176,45 @@ def test_subtrajectory_replay_buffer_may_produce_termination_transitions(strb_fo
         include_intermediate=True,
         rng=np.random.default_rng(0),
     )
-    assert terminated.any()
+    assert not terminated[:,:-1].any() and terminated[:,-1].any()
 
-def test_subtrajectory_replay_buffer_may_not_produce_truncation_transitions(strb_for_masking):
+
+def test_subtrajectory_replay_buffer_termination_transitions_are_always_last_with_next_ep(strb_for_masking):
     buf = strb_for_masking
+    # add termination transition before the next episode
+    add(buf, obs=4, next_obs=5, term=True, trunc=False)
+    add(buf, obs=5, next_obs=6, term=False, trunc=False)
+    add(buf, obs=6, next_obs=7, term=False, trunc=False)
+
+    _, _, _, _, terminated, _ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not terminated[:,:-1].any() and terminated[:,-1].any()
+
+
+def test_subtrajectory_replay_buffer_may_not_produce_truncation_transitions_without_next_ep(strb_for_masking):
+    buf = strb_for_masking
+    # add truncation transition as the last transition
     add(buf, obs=4, next_obs=5, term=False, trunc=True)
+
+    _, _, _, _, _, truncated = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not truncated.any()
+
+
+def test_subtrajectory_replay_buffer_may_not_produce_truncation_transitions_with_next_ep(strb_for_masking):
+    buf = strb_for_masking
+    # add truncation transition before the next episode
+    add(buf, obs=4, next_obs=5, term=False, trunc=True)
+    add(buf, obs=5, next_obs=6, term=False, trunc=False)
+    add(buf, obs=6, next_obs=7, term=False, trunc=False)
 
     _, _, _, _, _, truncated = buf.sample_batch(
         batch_size=100,

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from rl_blox.blox.replay_buffer import ReplayBuffer, SubtrajectoryReplayBuffer
+from rl_blox.blox.replay_buffer import ReplayBuffer, SubtrajectoryReplayBuffer, dilate_right
 
 
 def test_pickle_replay_buffer():
@@ -100,6 +100,30 @@ def add(buffer, obs, next_obs, term, trunc):
         terminated=term,
         truncated=trunc,
     )
+
+@pytest.fixture
+def mask():
+    return np.array([0, 0, 0, 1, 1, 0, 0, 0, 1, 0, 0, 0, 1, 0])
+
+
+def test_dilate_right_0(mask):
+    assert (dilate_right(mask, 0) == mask).all()
+
+
+def test_dilate_right_1(mask):
+    target = np.array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1])
+    assert (dilate_right(mask, 1) == target).all()
+
+
+def test_dilate_right_2(mask):
+    target = np.array([1, 0, 0, 1, 1, 1, 1, 0, 1, 1, 1, 0, 1, 1])
+    assert (dilate_right(mask, 2) == target).all()
+
+
+def test_dilate_right_3(mask):
+    target = np.array([1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])
+    assert (dilate_right(mask, 3) == target).all()
+
 
 @pytest.fixture
 def empty_strb():

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -1,7 +1,9 @@
 import os
 import pickle
+import pytest
 
 import gymnasium as gym
+import jax.numpy as jnp
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
@@ -50,7 +52,7 @@ def test_pickle_replay_buffer():
             os.remove(filename)
 
 
-def test_episodic_replay_buffer():
+def test_subtrajectory_replay_buffer():
     buffer = SubtrajectoryReplayBuffer(buffer_size=10_000, horizon=5)
 
     n_steps = 2_000
@@ -88,3 +90,57 @@ def test_episodic_replay_buffer():
     assert batch.observation.shape[2] == 3
 
     assert np.count_nonzero(buffer.mask_) == n_steps - n_episodes * 5
+
+def add(buffer, obs, next_obs, term, trunc):
+    buffer.add_sample(
+        observation=float(obs),
+        action=12,
+        reward=7,
+        next_observation=float(next_obs),
+        terminated=term,
+        truncated=trunc,
+    )
+
+@pytest.fixture
+def strb_for_masking():
+    buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
+    for i in range(4):
+        add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
+    return buf
+
+def test_subtrajectory_replay_buffer_no_end(strb_for_masking):
+    buf = strb_for_masking
+    add(buf, obs=4, next_obs=5, term=False, trunc=False)
+    assert (buf.current_len == 5)
+    assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
+def test_subtrajectory_replay_buffer_termination(strb_for_masking):
+    buf = strb_for_masking
+    add(buf, obs=4, next_obs=5, term=True, trunc=False)
+    assert (buf.current_len == 6)
+    assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
+def test_subtrajectory_replay_buffer_truncation(strb_for_masking):
+    buf = strb_for_masking
+    add(buf, obs=4, next_obs=5, term=False, trunc=True)
+    assert (buf.current_len == 6)
+    assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
+def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
+    buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
+    for i in range(4): # all non-negative
+        add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
+    add(buf, obs=4, next_obs=5, term=True, trunc=False) # still non-negative
+
+    for i in range(-4, 0): # next episode, all negative
+        add(buf, obs=i, next_obs=i-1, term=False, trunc=False)
+
+    obs_subseqs, *_ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    for obs_subseq in obs_subseqs:
+        assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
+

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -101,11 +101,21 @@ def add(buffer, obs, next_obs, term, trunc):
         truncated=trunc,
     )
 
+@pytest.fixture
+def empty_strb():
+    return SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
 
 @pytest.fixture
-def strb_for_masking():
-    buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
+def strb_for_masking(empty_strb):
+    buf = empty_strb
     for i in range(4):
+        add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
+    return buf
+
+@pytest.fixture
+def full_strb(empty_strb):
+    buf = empty_strb
+    for i in range(10):
         add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
     return buf
 
@@ -146,7 +156,7 @@ def test_subtrajectory_replay_buffer_has_horizon_as_min_episode_len():
     )
 
 
-def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
+def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination():
     buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
     for i in range(4): # all non-negative
         add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
@@ -215,6 +225,110 @@ def test_subtrajectory_replay_buffer_may_not_produce_truncation_transitions_with
     add(buf, obs=4, next_obs=5, term=False, trunc=True)
     add(buf, obs=5, next_obs=6, term=False, trunc=False)
     add(buf, obs=6, next_obs=7, term=False, trunc=False)
+
+    _, _, _, _, _, truncated = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not truncated.any()
+
+# From here: Same tests as before, just on an already full buffer
+# (as far as they apply here). They are arranged so that generally
+# the most interesting index for each test respectively (i.e., newest
+# transition, termination, truncation, ...) is at buffer index 0.
+
+def test_subtrajectory_replay_buffer_full_no_end(full_strb):
+    buf = full_strb
+    add(buf, obs=10, next_obs=11, term=False, trunc=False)
+    assert (buf.current_len == 10)
+    assert (buf.mask_ == jnp.array([0, 1, 1, 1, 1, 1, 1, 1, 1, 0])).all()
+
+
+def test_subtrajectory_replay_buffer_full_termination(full_strb):
+    buf = full_strb
+    add(buf, obs=10, next_obs=11, term=True, trunc=False)
+    assert (buf.current_len == 10)
+    assert (buf.mask_ == jnp.array([0, 1, 1, 1, 1, 1, 1, 1, 1, 0])).all()
+
+
+def test_subtrajectory_replay_buffer_full_truncation(full_strb):
+    buf = full_strb
+    add(buf, obs=10, next_obs=11, term=False, trunc=True)
+    assert (buf.current_len == 10)
+    assert (buf.mask_ == jnp.array([0, 1, 1, 1, 1, 1, 1, 1, 0, 0])).all()
+
+
+def test_subtrajectory_replay_buffer_full_respects_episode_boundaries_on_termination():
+    buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
+    for i in range(10): # all non-negative
+        add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
+    add(buf, obs=10, next_obs=11, term=True, trunc=False) # still non-negative
+
+    for i in range(-4, 0): # next episode, all negative
+        add(buf, obs=i, next_obs=i-1, term=False, trunc=False)
+
+    obs_subseqs, *_ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    for obs_subseq in obs_subseqs:
+        assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
+
+
+def test_subtrajectory_replay_buffer_full_termination_transitions_are_always_last_without_next_ep(full_strb):
+    buf = full_strb
+    # add termination transition as the last transition
+    add(buf, obs=10, next_obs=11, term=True, trunc=False)
+
+    _, _, _, _, terminated, _ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not terminated[:,:-1].any() and terminated[:,-1].any()
+
+
+def test_subtrajectory_replay_buffer_full_termination_transitions_are_always_last_with_next_ep(full_strb):
+    buf = full_strb
+    # add termination transition before the next episode
+    add(buf, obs=10, next_obs=11, term=True, trunc=False)
+    add(buf, obs=11, next_obs=12, term=False, trunc=False)
+    add(buf, obs=12, next_obs=13, term=False, trunc=False)
+
+    _, _, _, _, terminated, _ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not terminated[:,:-1].any() and terminated[:,-1].any()
+
+
+def test_subtrajectory_replay_buffer_full_may_not_produce_truncation_transitions_without_next_ep(full_strb):
+    buf = full_strb
+    # add truncation transition as the last transition
+    add(buf, obs=10, next_obs=11, term=False, trunc=True)
+
+    _, _, _, _, _, truncated = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not truncated.any()
+
+
+def test_subtrajectory_replay_buffer_full_may_not_produce_truncation_transitions_with_next_ep(full_strb):
+    buf = full_strb
+    # add truncation transition before the next episode
+    add(buf, obs=10, next_obs=11, term=False, trunc=True)
+    add(buf, obs=11, next_obs=12, term=False, trunc=False)
+    add(buf, obs=12, next_obs=13, term=False, trunc=False)
 
     _, _, _, _, _, truncated = buf.sample_batch(
         batch_size=100,

--- a/tests/test_replay_buffer.py
+++ b/tests/test_replay_buffer.py
@@ -112,19 +112,33 @@ def test_subtrajectory_replay_buffer_no_end(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=False, trunc=False)
     assert (buf.current_len == 5)
-    assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+    assert (buf.mask_ == jnp.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])).all()
 
 def test_subtrajectory_replay_buffer_termination(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=True, trunc=False)
     assert (buf.current_len == 6)
-    assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+    assert (buf.mask_ == jnp.array([1, 1, 1, 0, 0, 0, 0, 0, 0, 0])).all()
 
 def test_subtrajectory_replay_buffer_truncation(strb_for_masking):
     buf = strb_for_masking
     add(buf, obs=4, next_obs=5, term=False, trunc=True)
     assert (buf.current_len == 6)
     assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
+
+def test_subtrajectory_replay_buffer_has_horizon_as_min_episode_len():
+    buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
+    for i in range(3):
+        add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
+    assert buf.mask_.any()
+    # ensure subtrajectories can be generated from a minimum-length episode
+    # otherwise an error will be thrown
+    _ = buf.sample_batch(
+        batch_size=1,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
 
 def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
     buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
@@ -144,3 +158,26 @@ def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(
     for obs_subseq in obs_subseqs:
         assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
 
+def test_subtrajectory_replay_buffer_may_produce_termination_transitions(strb_for_masking):
+    buf = strb_for_masking
+    add(buf, obs=4, next_obs=5, term=True, trunc=False)
+
+    _, _, _, _, terminated, _ = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert terminated.any()
+
+def test_subtrajectory_replay_buffer_may_not_produce_truncation_transitions(strb_for_masking):
+    buf = strb_for_masking
+    add(buf, obs=4, next_obs=5, term=False, trunc=True)
+
+    _, _, _, _, _, truncated = buf.sample_batch(
+        batch_size=100,
+        horizon=3,
+        include_intermediate=True,
+        rng=np.random.default_rng(0),
+    )
+    assert not truncated.any()


### PR DESCRIPTION
_Update:_ As a fix, I propose not setting the mask to 1 in the non-truncated (i.e., terminated) case (see second commit). While I do not see a use for the remaining setting the mask to 0 in the truncated case, it does not seem to cause problems and removing it would risk breaking it in case it does have a use.

---

This provides tests that check `SubtrajectoryReplayBuffer`'s behavior when a new sample (transition) is added that indicates the current episode was truncated or terminated.

The hypothesis is that the `mask_`, which masks out potential starting indices for subtrajectories so they will not be used for samples, is changed incorrectly: When a truncation transition is added, the mask remains unchanged, as the indices masked out (set to 0) were masked out before already. When a termination transition is added, the code masks in starting indices that should not be masked in, which leads to `sample_batch()` producing subtrajectories that do not respect the border between episodes, i.e., a subtrajectory may start in one episode and end in the next, including transitions from both.

```python
...
self.mask_[self.insert_idx % self.buffer_size] = 0
past_idx = (
    self.insert_idx
    - np.arange(min(self.episode_timesteps, self.horizon))
    - 1
) % self.buffer_size
self.mask_[past_idx] = (
    0 if sample["truncated"] else 1
)  # mask out truncated subtrajectories
...
```
See the lines in context [here](https://github.com/adrian-schucht/rl-blox/blob/b856c20081cb27f263c99951b1a38f213e3bc1ff/rl_blox/blox/replay_buffer.py#L255-L263).

Tests were added that confirm this behavior. Most importantly, see the last test, which shows that trajectories may contain more than one episode's transitions: `test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(...)`. This test work by adding samples from one episode with non-negative observations, then terminating this episode and continuing to add samples from the next episode with *negative* observations, before sampling from the buffer to show that the sampled trajectories contain both non-negative and negative observations. Relevant test output:

```
______________________________ test_subtrajectory_replay_buffer_termination ______________________________

strb_for_masking = <rl_blox.blox.replay_buffer.SubtrajectoryReplayBuffer object at 0x7cb036bbc230>

    def test_subtrajectory_replay_buffer_termination(strb_for_masking):
        buf = strb_for_masking
        add(buf, obs=4, next_obs=5, term=True, trunc=False)
        assert (buf.current_len == 6)
>       assert (buf.mask_ == jnp.array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0])).all()
E       assert Array(False, dtype=bool)
E        +  where Array(False, dtype=bool) = _all()
E        +    where _all = array([1, 1, ..., 0, 0, 0, 0]) == Array([1, 1, ..., dtype=int32)
E
E             Full diff:
E             - Array([1, 1, 0, 0, 0, 0, 0, 0, 0, 0], dtype=int32)
E             + array([1, 1, 1, 1, 1, 0, 0, 0, 0, 0]).all

tests/test_replay_buffer.py:121: AssertionError
______________ test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination _______________

strb_for_masking = <rl_blox.blox.replay_buffer.SubtrajectoryReplayBuffer object at 0x7caf84197560>

    def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
        buf = SubtrajectoryReplayBuffer(buffer_size=10, horizon=3)
        for i in range(4): # all non-negative
            add(buf, obs=i, next_obs=i+1, term=False, trunc=False)
        add(buf, obs=4, next_obs=5, term=True, trunc=False) # still non-negative

        for i in range(-4, 0): # next episode, all negative
            add(buf, obs=i, next_obs=i-1, term=False, trunc=False)

        obs_subseqs, *_ = buf.sample_batch(
            batch_size=100,
            horizon=3,
            include_intermediate=True,
            rng=np.random.default_rng(0),
        )
        for obs_subseq in obs_subseqs:
>           assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
E           assert (Array(False, dtype=bool) or Array(False, dtype=bool))
E            +  where Array(False, dtype=bool) = _all()
E            +    where _all = Array([ 4.,  5., -4.], dtype=float32) >= 0.all
E            +  and   Array(False, dtype=bool) = _all()
E            +    where _all = Array([ 4.,  5., -4.], dtype=float32) <= 0.all

tests/test_replay_buffer.py:145: AssertionError
```

## MRQ

The code for `SubtrajectoryReplayBuffer` was adapted from MRQ's `ReplayBuffer`. Similar tests confirm that this code shares the same behavior (see the tests [here](https://github.com/facebookresearch/MRQ/commit/1848ab902c1dfa9eceb6b9017b99afcca401ffa8)). Relevant test output:

```
______________________________ test_subtrajectory_replay_buffer_termination ______________________________

strb_for_masking = <MRQ.buffer.ReplayBuffer object at 0x7c57edee0770>

    def test_subtrajectory_replay_buffer_termination(strb_for_masking):
        strb_for_masking.add(
            state=torch.tensor([4.0]),
            action=12.0,
            reward=7,
            next_state=torch.tensor([5.0]),
            terminated=True,
            truncated=False,
        )
>       assert (strb_for_masking.mask == torch.tensor([1.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])).all()
E       assert tensor(False)
E        +  where tensor(False) = <built-in method all of Tensor object at 0x7c56fa877f20>()
E        +    where <built-in method all of Tensor object at 0x7c56fa877f20> = tensor([1., 1..., 0., 0., 0.]) == tensor([1., 1..., 0., 0., 0.])
E
E             Full diff:
E             - tensor([1., 1., 0., 0., 0., 0., 0., 0., 0., 0.])
E             ?                                ------------
E             + tensor([1., 1., 1., 1., 1., 0., 0., 0., 0., 0.])
E             ?                 ++++++++++++.all

tests/test_replay_buffer.py:54: AssertionError
______________ test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination _______________

strb_for_masking = <MRQ.buffer.ReplayBuffer object at 0x7c57b4555220>

    def test_subtrajectory_replay_buffer_respects_episode_boundaries_on_termination(strb_for_masking):
        buffer = strb_for_masking # all non-negative
        buffer.add(
            state=torch.tensor([4.0]),
            action=12.0,
            reward=7,
            next_state=torch.tensor([5.0]),
            terminated=True,
            truncated=False,
        ) # still non-negative
        for i in range(-4, 0): # next episode, all negative
            buffer.add(
                state=torch.tensor([float(i)]),
                action=12.0,
                reward=7,
                next_state=torch.tensor([i-1.0]),
                terminated=False,
                truncated=False,
            )
        obs_subseqs, *_ = buffer.sample(
            horizon=3,
            include_intermediate=True,
        )
        for obs_subseq in obs_subseqs:
>           assert (obs_subseq >= 0).all() or (obs_subseq <= 0).all()
E           assert (tensor(False) or tensor(False))
E            +  where tensor(False) = <built-in method all of Tensor object at 0x7c56fa8dccd0>()
E            +    where <built-in method all of Tensor object at 0x7c56fa8dccd0> = tensor([[ 4.],\n        [ 0.],\n        [-4.]]) >= 0.all
E            +  and   tensor(False) = <built-in method all of Tensor object at 0x7c56fa8dcdc0>()
E            +    where <built-in method all of Tensor object at 0x7c56fa8dcdc0> = tensor([[ 4.],\n        [ 0.],\n        [-4.]]) <= 0.all

tests/test_replay_buffer.py:91: AssertionError
```